### PR TITLE
feat(activation): prevent orphaned MPS device records on re-provision

### DIFF
--- a/.rpsrc
+++ b/.rpsrc
@@ -25,5 +25,6 @@
   "consul_key_prefix": "RPS",
   "amt_legacy_tls_compatibility": true,
   "amt_post_tls_reject": true,
-  "amt_tls_tunnel_persistent": true
+  "amt_tls_tunnel_persistent": true,
+  "prevent_orphaned_devices": false
 }

--- a/src/Validator.ts
+++ b/src/Validator.ts
@@ -304,6 +304,7 @@ export class Validator implements IValidator {
     switch (msg.payload.currentMode) {
       case 0: {
         this.logger.debug(`Device ${msg.payload.uuid} is in pre-provisioning mode`)
+        await this.verifyDeviceNotAlreadyRegistered(msg, profile)
         break
       }
       case 1: {
@@ -331,6 +332,35 @@ export class Validator implements IValidator {
       default: {
         throw new RPSError(`Device ${msg.payload.uuid} activation failed. It is in unknown mode.`)
       }
+    }
+  }
+
+  /**
+   * When `prevent_orphaned_devices` is enabled, refuse to re-provision a currentMode=0 device that still has an MPS record; fails open on 404 or unreachable MPS.
+   */
+  async verifyDeviceNotAlreadyRegistered(msg: ClientMsg, profile: AMTConfiguration): Promise<void> {
+    if (Environment.Config.prevent_orphaned_devices !== true) {
+      return
+    }
+    let isRegistered = false
+    try {
+      const result = await got(
+        `${Environment.Config.mps_server}/api/v1/devices/${msg.payload.uuid}?tenantId=${profile.tenantId}`,
+        { method: 'GET' }
+      )
+      if (result?.body != null && result.body !== '') {
+        const existing = typeof result.body === 'string' ? JSON.parse(result.body) : result.body
+        isRegistered = existing?.guid != null
+      }
+    } catch (err) {
+      // Device not registered in MPS (404) or MPS unreachable: nothing to reconcile, allow.
+      return
+    }
+    if (isRegistered) {
+      throw new RPSError(
+        `Device ${msg.payload.uuid} already has a record in MPS and cannot be re-provisioned from ` +
+          `pre-provisioning mode. Remove the device (rpc-go deactivation or the REST API) before re-adding it.`
+      )
     }
   }
 

--- a/src/Validator.ts
+++ b/src/Validator.ts
@@ -336,7 +336,10 @@ export class Validator implements IValidator {
   }
 
   /**
-   * When `prevent_orphaned_devices` is enabled, refuse to re-provision a currentMode=0 device that still has an MPS record; fails open on 404 or unreachable MPS.
+   * When `prevent_orphaned_devices` is enabled, refuse to re-provision a currentMode=0 device that still has an MPS record.
+   * Fails open on any lookup failure (404, unreachable MPS, auth/server errors) so the flag never blocks activation
+   * when MPS cannot answer. A non-empty response that is not parseable JSON is treated as "registered" (fail closed),
+   * matching getDeviceFromMPS in the activation state machine.
    */
   async verifyDeviceNotAlreadyRegistered(msg: ClientMsg, profile: AMTConfiguration): Promise<void> {
     if (Environment.Config.prevent_orphaned_devices !== true) {
@@ -345,15 +348,20 @@ export class Validator implements IValidator {
     let isRegistered = false
     try {
       const result = await got(
-        `${Environment.Config.mps_server}/api/v1/devices/${msg.payload.uuid}?tenantId=${profile.tenantId}`,
+        `${Environment.Config.mps_server}/api/v1/devices/${msg.payload.uuid}?tenantId=${encodeURIComponent(profile.tenantId ?? '')}`,
         { method: 'GET' }
       )
       if (result?.body != null && result.body !== '') {
-        const existing = typeof result.body === 'string' ? JSON.parse(result.body) : result.body
-        isRegistered = existing?.guid != null
+        try {
+          const existing = typeof result.body === 'string' ? JSON.parse(result.body) : result.body
+          isRegistered = existing?.guid != null
+        } catch {
+          // MPS returned a non-empty but unparseable body for this GUID: assume a record exists.
+          isRegistered = true
+        }
       }
     } catch (err) {
-      // Device not registered in MPS (404) or MPS unreachable: nothing to reconcile, allow.
+      this.logger.debug(`MPS lookup for ${msg.payload.uuid} failed (${err?.message ?? err}); allowing activation`)
       return
     }
     if (isRegistered) {

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -116,6 +116,7 @@ export interface RPSConfig {
   amt_post_tls_reject: boolean
   amt_legacy_tls_compatibility?: boolean
   amt_tls_tunnel_persistent?: boolean
+  prevent_orphaned_devices?: boolean
 }
 export enum AMTRedirectionServiceEnabledStates {
   DISABLED = 32768,

--- a/src/utils/Environment.ts
+++ b/src/utils/Environment.ts
@@ -33,6 +33,10 @@ config.amt_legacy_tls_compatibility = config.amt_legacy_tls_compatibility ?? fal
 // When true, the TLS tunnel is reused across WSMAN calls (keep-alive). When false,
 // the tunnel is torn down and re-established for every message (Connection: close).
 config.amt_tls_tunnel_persistent = config.amt_tls_tunnel_persistent ?? true
+// When true, a device that reports pre-provisioning mode but still has a record in the
+// MPS devices table must be removed (rpc-go deactivation or the REST API) before it can be
+// re-provisioned. Keeps the MPS devices table free of orphaned records. Off by default.
+config.prevent_orphaned_devices = config.prevent_orphaned_devices ?? false
 log.silly(`config: ${JSON.stringify(config, null, 2)}`)
 
 const Environment = {

--- a/src/validator.test.ts
+++ b/src/validator.test.ts
@@ -551,8 +551,10 @@ describe('validator', () => {
       msg.payload.currentMode = 0
       Environment.Config.prevent_orphaned_devices = true
       devices[clientId] = { ClientId: clientId, ClientSocket: null as any, unauthCount: 0, status: {} } as any
+      vi.mocked(got).mockClear()
       vi.mocked(got).mockResolvedValue({ body: '' } as any)
       await validator.verifyCurrentModeForActivation(msg, profile, clientId)
+      expect(got).toHaveBeenCalledTimes(1)
       expect(devices[clientId].status.Status).toBeUndefined()
     })
     test('should throw when current mode is 0 but a device record still exists in MPS', async () => {
@@ -573,9 +575,30 @@ describe('validator', () => {
       msg.payload.currentMode = 0
       Environment.Config.prevent_orphaned_devices = true
       devices[clientId] = { ClientId: clientId, ClientSocket: null as any, unauthCount: 0, status: {} } as any
+      vi.mocked(got).mockClear()
       vi.mocked(got).mockRejectedValue(new Error('Response code 404'))
       await validator.verifyCurrentModeForActivation(msg, profile, clientId)
+      expect(got).toHaveBeenCalledTimes(1)
       expect(devices[clientId].status.Status).toBeUndefined()
+    })
+    test('should throw when current mode is 0 and MPS returns a non-empty unparseable body (fails closed)', async () => {
+      msg.payload.currentMode = 0
+      Environment.Config.prevent_orphaned_devices = true
+      devices[clientId] = { ClientId: clientId, ClientSocket: null as any, unauthCount: 0, status: {} } as any
+      vi.mocked(got).mockResolvedValue({ body: 'not json' } as any)
+      await expect(validator.verifyCurrentModeForActivation(msg, profile, clientId)).rejects.toThrow(
+        'already has a record in MPS'
+      )
+    })
+    test('should URL-encode tenantId in the MPS lookup', async () => {
+      msg.payload.currentMode = 0
+      Environment.Config.prevent_orphaned_devices = true
+      profile.tenantId = 'a b/c'
+      devices[clientId] = { ClientId: clientId, ClientSocket: null as any, unauthCount: 0, status: {} } as any
+      vi.mocked(got).mockClear()
+      vi.mocked(got).mockResolvedValue({ body: '' } as any)
+      await validator.verifyCurrentModeForActivation(msg, profile, clientId)
+      expect(vi.mocked(got).mock.calls[0][0]).toContain('tenantId=a%20b%2Fc')
     })
     test('should set status as already enabled in client mode, when current mode is 1', async () => {
       msg.payload.currentMode = 1

--- a/src/validator.test.ts
+++ b/src/validator.test.ts
@@ -15,8 +15,10 @@ import { VersionChecker } from './VersionChecker.js'
 import { devices } from './devices.js'
 import { ClientAction, type ClientObject } from './models/RCS.Config.js'
 import { type DeviceCredentials } from './interfaces/ISecretManagerService.js'
+import got from 'got'
 
 import { vi } from 'vitest'
+vi.mock('got')
 Environment.Config = config
 const configurator: Configurator = new Configurator()
 const validator = new Validator(new Logger('Validator'), configurator)
@@ -533,9 +535,45 @@ describe('validator', () => {
       }
       setNextStepsForConfigurationSpy = vi.spyOn(validator, 'setNextStepsForConfiguration')
     })
-    test('should set nothing when current mode is 0', async () => {
+    afterEach(() => {
+      Environment.Config.prevent_orphaned_devices = false
+    })
+    test('should set nothing when current mode is 0 and orphan prevention is disabled (default)', async () => {
       msg.payload.currentMode = 0
+      Environment.Config.prevent_orphaned_devices = false
+      vi.mocked(got).mockClear()
       devices[clientId] = { ClientId: clientId, ClientSocket: null as any, unauthCount: 0, status: {} } as any
+      await validator.verifyCurrentModeForActivation(msg, profile, clientId)
+      expect(devices[clientId].status.Status).toBeUndefined()
+      expect(got).not.toHaveBeenCalled()
+    })
+    test('should set nothing when current mode is 0 and device has no MPS record', async () => {
+      msg.payload.currentMode = 0
+      Environment.Config.prevent_orphaned_devices = true
+      devices[clientId] = { ClientId: clientId, ClientSocket: null as any, unauthCount: 0, status: {} } as any
+      vi.mocked(got).mockResolvedValue({ body: '' } as any)
+      await validator.verifyCurrentModeForActivation(msg, profile, clientId)
+      expect(devices[clientId].status.Status).toBeUndefined()
+    })
+    test('should throw when current mode is 0 but a device record still exists in MPS', async () => {
+      msg.payload.currentMode = 0
+      Environment.Config.prevent_orphaned_devices = true
+      devices[clientId] = { ClientId: clientId, ClientSocket: null as any, unauthCount: 0, status: {} } as any
+      vi.mocked(got).mockResolvedValue({ body: JSON.stringify({ guid: msg.payload.uuid }) } as any)
+      let rpsError: any = null
+      try {
+        await validator.verifyCurrentModeForActivation(msg, profile, clientId)
+      } catch (error) {
+        rpsError = error
+      }
+      expect(rpsError).toBeInstanceOf(RPSError)
+      expect(rpsError.message).toContain('already has a record in MPS')
+    })
+    test('should proceed when current mode is 0 and MPS has no record (fails open)', async () => {
+      msg.payload.currentMode = 0
+      Environment.Config.prevent_orphaned_devices = true
+      devices[clientId] = { ClientId: clientId, ClientSocket: null as any, unauthCount: 0, status: {} } as any
+      vi.mocked(got).mockRejectedValue(new Error('Response code 404'))
       await validator.verifyCurrentModeForActivation(msg, profile, clientId)
       expect(devices[clientId].status.Status).toBeUndefined()
     })


### PR DESCRIPTION
Add the opt-in `prevent_orphaned_devices` config flag (default off). When enabled, a device reporting pre-provisioning mode (currentMode=0) that still has a record in the MPS devices table is refused until it is removed via rpc-go deactivation or the REST API, keeping the devices table free of orphaned/duplicate records. Disabled by default, so existing behavior is unchanged. Fails open if MPS is unreachable or the device is not registered.

## PR Checklist

<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Unit Tests have been added for new changes
- [ ] API tests have been updated if applicable
- [ ] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.

## What are you changing?

<!-- Please provide a short description of the updates that are in the PR -->

## Anything the reviewer should know when reviewing this PR?

### If the there are associated PRs in other repositories, please link them here (i.e. device-management-toolkit/repo#365 )
