### PR TITLE
ci(gh-actions): drop node 20 support

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [22.x, 24.X]
+        node-version: [22.x, 24.x]
 
     steps:
       - name: Harden Runner

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=20.19.0"
+    "node": ">=22"
   },
   "type": "module",
   "exports": "./index.js",


### PR DESCRIPTION
Every rps workflow already runs 22 or newer -- the test matrix covers 22 and 24, and release.yml and semantic.yml are both on 24.x -- so Node 20 has not been exercised anywhere for a while. engines.node was the only place still claiming support for it.

Also normalises the matrix entry 24.X to 24.x so it matches the three matrix.node-version == '24.x' conditions literally. Those conditions already worked, because GitHub Actions string comparison is case-insensitive, but the mismatch was confusing and it made the artifact name rps-unit-24.X.

## PR Checklist

<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Unit Tests have been added for new changes
- [ ] API tests have been updated if applicable
- [ ] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.

## What are you changing?

<!-- Please provide a short description of the updates that are in the PR -->

## Anything the reviewer should know when reviewing this PR?

### If the there are associated PRs in other repositories, please link them here (i.e. device-management-toolkit/repo#365 )
