### PR TITLE
ci(gh-actions): group vitest dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,13 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+    # vitest and @vitest/* release in lockstep and declare exact peers on each
+    # other; one PR instead of a split that cannot install.
+    groups:
+      vitest:
+        patterns:
+          - 'vitest'
+          - '@vitest/*'
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
Adds an npm `groups` entry so Dependabot raises `vitest` and `@vitest/*` as a single PR.

### Why

`@vitest/coverage-v8` declares an **exact** peer on the matching `vitest` version. Split across separate PRs, each side pairs a 5.0.0 package with a 4.x sibling and `npm ci` fails:

```
npm error code ERESOLVE
npm error While resolving: @vitest/coverage-v8@5.0.0
npm error Found: vitest@4.1.11
npm error   peer vitest@"5.0.0" from @vitest/coverage-v8@5.0.0
```

That is exactly what happened with #2894 and #2895 — both red on `build`, `build (22.x)`, `build (24.X)`, `docker` and `Validate PR and Commits`. #2899 fixes the current bump by hand; this stops it recurring.

The `github-actions` ecosystem already uses this pattern for `codeql-action`, for the same lockstep reason.

### Scope

Deliberately limited to vitest, matching device-management-toolkit/mps#2655. There is a case for grouping other lockstep pairs (runtime packages with their `@types/*` — that split caused a separate failure in mps), but that is left out to keep this reviewable.

### Note

Grouping only affects **future** Dependabot PRs; it does not retroactively combine existing ones.
